### PR TITLE
Replace lowlighter/metrics with gh-metrics/metrics

### DIFF
--- a/.github/workflows/Metrics.yml
+++ b/.github/workflows/Metrics.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: lowlighter/metrics@latest
+      - uses: gh-metrics/metrics@latest
         with:
           # Your GitHub token
           # The following scopes are required:
@@ -35,7 +35,7 @@ jobs:
           plugin_notable: yes
           plugin_notable_from: all
           plugin_notable_types: commit
-      - uses: lowlighter/metrics@latest
+      - uses: gh-metrics/metrics@latest
         with:
           token: ${{ secrets.METRICS_TOKEN }}
           filename: metrics_right.svg


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for metrics collection by switching from the `lowlighter/metrics` action to the new `gh-metrics/metrics` action. This change is applied to all relevant steps in the `.github/workflows/Metrics.yml` file.

**Workflow action update:**

* Replaced all uses of `lowlighter/metrics@latest` with `gh-metrics/metrics@latest` in the `.github/workflows/Metrics.yml` workflow to use the new metrics action. [[1]](diffhunk://#diff-71124d25a02b0646d8fdb90b17017f6251f7b954f4e9893d06ae1e13367f1c81L15-R15) [[2]](diffhunk://#diff-71124d25a02b0646d8fdb90b17017f6251f7b954f4e9893d06ae1e13367f1c81L38-R38)